### PR TITLE
Refactored the codebase

### DIFF
--- a/src/main/java/pl/eukon05/pk4j/core/EHMSUrlEnum.java
+++ b/src/main/java/pl/eukon05/pk4j/core/EHMSUrlEnum.java
@@ -1,0 +1,4 @@
+package pl.eukon05.pk4j.core;
+
+public interface EHMSUrlEnum {
+}

--- a/src/main/java/pl/eukon05/pk4j/core/EHMSUser.java
+++ b/src/main/java/pl/eukon05/pk4j/core/EHMSUser.java
@@ -1,13 +1,8 @@
 package pl.eukon05.pk4j.core;
 
-import java.util.Optional;
-
 public class EHMSUser {
     private final String username;
-    private String userID;
     private final String password;
-    private String studyID;
-    private String sessionToken;
 
     private EHMSUser(String username, String password) {
         if (username == null || password == null)
@@ -27,32 +22,7 @@ public class EHMSUser {
     public String getUsername() {
         return username;
     }
-
     public String getPassword() {
         return password;
-    }
-
-    public Optional<String> getUserID() {
-        return Optional.ofNullable(userID);
-    }
-
-    public void setUserID(String userID) {
-        this.userID = userID;
-    }
-
-    public Optional<String> getStudyID() {
-        return Optional.ofNullable(studyID);
-    }
-
-    public void setStudyID(String studyID) {
-        this.studyID = studyID;
-    }
-
-    public Optional<String> getSessionToken() {
-        return Optional.ofNullable(sessionToken);
-    }
-
-    public void setSessionToken(String sessionToken) {
-        this.sessionToken = sessionToken;
     }
 }

--- a/src/main/java/pl/eukon05/pk4j/core/EHMSUserSession.java
+++ b/src/main/java/pl/eukon05/pk4j/core/EHMSUserSession.java
@@ -1,0 +1,13 @@
+package pl.eukon05.pk4j.core;
+
+public abstract class EHMSUserSession {
+    protected String sessionToken;
+
+    public EHMSUserSession(String sessionToken) {
+        this.sessionToken = sessionToken;
+    }
+
+    public final String getSessionToken() {
+        return sessionToken;
+    }
+}

--- a/src/main/java/pl/eukon05/pk4j/core/EHMSWebClient.java
+++ b/src/main/java/pl/eukon05/pk4j/core/EHMSWebClient.java
@@ -1,0 +1,13 @@
+package pl.eukon05.pk4j.core;
+
+import com.google.gson.JsonObject;
+import pl.eukon05.pk4j.exception.EHMSExpiredTokenException;
+import pl.eukon05.pk4j.exception.InvalidCredentialsException;
+
+import java.io.IOException;
+
+public interface EHMSWebClient {
+    EHMSUserSession login(EHMSUser user) throws IOException, InterruptedException, InvalidCredentialsException;
+    JsonObject getRequest(EHMSUserSession session, EHMSUrlEnum store) throws IOException, InterruptedException, EHMSExpiredTokenException;
+    JsonObject getRequest(EHMSUserSession session, EHMSUrlEnum store, long resourceID) throws IOException, InterruptedException, EHMSExpiredTokenException;
+}

--- a/src/main/java/pl/eukon05/pk4j/core/PK4J.java
+++ b/src/main/java/pl/eukon05/pk4j/core/PK4J.java
@@ -2,22 +2,39 @@ package pl.eukon05.pk4j.core;
 
 import pl.eukon05.pk4j.core.impl.rest.RestPK4J;
 import pl.eukon05.pk4j.core.impl.scraper.ScraperPK4J;
+import pl.eukon05.pk4j.exception.InvalidCredentialsException;
 import pl.eukon05.pk4j.model.Announcement;
 import pl.eukon05.pk4j.model.UserDetails;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public interface PK4J {
-    List<Announcement> getAnnouncements(EHMSUser user) throws IOException, InterruptedException;
+public abstract class PK4J {
+    protected final Map<String, EHMSUserSession> sessionCache = new HashMap<>();
+    protected final EHMSWebClient client;
 
-    UserDetails getUserDetails(EHMSUser user) throws IOException, InterruptedException;
+    protected PK4J(EHMSWebClient client) {
+        this.client = client;
+    }
 
-    static PK4J getInstance() {
+    protected final EHMSUserSession getSession(EHMSUser user) throws InvalidCredentialsException, IOException, InterruptedException {
+        if (!sessionCache.containsKey(user.getUsername()))
+            sessionCache.put(user.getUsername(), client.login(user));
+
+        return sessionCache.get(user.getUsername());
+    }
+
+    public abstract List<Announcement> getAnnouncements(EHMSUser user) throws IOException, InterruptedException, InvalidCredentialsException;
+
+    public abstract UserDetails getUserDetails(EHMSUser user) throws IOException, InterruptedException, InvalidCredentialsException;
+
+    public static PK4J getInstance() {
         return ScraperPK4J.getInstance();
     }
 
-    static PK4J getInstance(boolean useRest) {
+    public static PK4J getInstance(boolean useRest) {
         return useRest ? RestPK4J.getInstance() : ScraperPK4J.getInstance();
     }
 }

--- a/src/main/java/pl/eukon05/pk4j/core/impl/rest/JsonToModelMapper.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/rest/JsonToModelMapper.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-class JsonToModelMapper {
+final class JsonToModelMapper {
     Announcement announcementFromJson(JsonObject object, long id) {
         return new Announcement(id,
                 object.get("title").getAsString(),

--- a/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestEHMSUrl.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestEHMSUrl.java
@@ -1,6 +1,8 @@
 package pl.eukon05.pk4j.core.impl.rest;
 
-enum RestEHMSUrl {
+import pl.eukon05.pk4j.core.EHMSUrlEnum;
+
+enum RestEHMSUrl implements EHMSUrlEnum {
     AUTHENTICATE("https://ehms.pk.edu.pl/api/users/authenticate"),
     ALL_ANNOUNCEMENTS("https://ehms.pk.edu.pl/api/announcements"),
     ANNOUNCEMENT("https://ehms.pk.edu.pl/api/announcements/announcement"),

--- a/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestEHMSWebClient.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestEHMSWebClient.java
@@ -4,8 +4,13 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.eukon05.pk4j.core.EHMSUrlEnum;
 import pl.eukon05.pk4j.core.EHMSUser;
+import pl.eukon05.pk4j.core.EHMSUserSession;
+import pl.eukon05.pk4j.core.EHMSWebClient;
 import pl.eukon05.pk4j.exception.EHMSException;
+import pl.eukon05.pk4j.exception.EHMSExpiredTokenException;
+import pl.eukon05.pk4j.exception.InvalidCredentialsException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -13,81 +18,76 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
-class RestEHMSWebClient {
+final class RestEHMSWebClient implements EHMSWebClient {
     private final HttpClient client = HttpClient.newHttpClient();
     private final Gson gson = new Gson();
     private final Logger logger = LoggerFactory.getLogger(RestEHMSWebClient.class);
 
-
-    JsonObject getRequest(EHMSUser user, RestEHMSUrl url) throws IOException, InterruptedException {
-        return getRequest(user, url, -1);
+    public JsonObject getRequest(EHMSUserSession session, EHMSUrlEnum url) throws IOException, InterruptedException {
+        return getRequest(session, url, -1);
     }
 
-    JsonObject getRequest(EHMSUser user, RestEHMSUrl url, long resourceID) throws IOException, InterruptedException {
-        if (user.getSessionToken().isEmpty()) {
-            logger.debug("User {} didn't have a session token attached, trying to log in...", user.getUsername());
-            login(user);
-            return getRequest(user, url);
+    public JsonObject getRequest(EHMSUserSession session, EHMSUrlEnum url, long resourceID) throws IOException, InterruptedException {
+        String value;
+        if (url instanceof RestEHMSUrl restEHMSUrl)
+            value = restEHMSUrl.value();
+        else {
+            logger.error("Using URLs from other PK4J implementations is unsupported!");
+            throw new IllegalArgumentException("url must be an instance of RestEHMSUrl");
         }
 
-        if (user.getStudyID().isEmpty() || user.getUserID().isEmpty()) {
-            logger.warn("""
-                    User {} was previously logged in via a different PK4J implementation.
-                    Please, DO NOT reuse the same user object across different implementations of PK4J, to avoid unnecessary logins.
-                    Trying to log in...
-                    """, user.getUsername());
-            login(user);
-            return getRequest(user, url);
+        if (session instanceof RestUserSession restUserSession) {
+            StringBuilder urlBuilder = new StringBuilder(value);
+
+            if (resourceID != -1) {
+                urlBuilder.append("/").append(resourceID);
+            }
+
+            urlBuilder.append("?user_id=").append(restUserSession.getUserID());
+            urlBuilder.append("&study_id=").append(restUserSession.getStudyID());
+
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(urlBuilder.toString())).header("Content-Type", "application/json").header("Authorization", String.join("", "Bearer ", restUserSession.getSessionToken())).GET().build();
+
+            logger.debug("Trying to retrieve data from {}", urlBuilder);
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 401) {
+                logger.debug("Unable to retrieve data from {}, session expired", urlBuilder);
+                throw new EHMSExpiredTokenException();
+            }
+
+            if (response.statusCode() != 200) throw new EHMSException(response.statusCode());
+
+            logger.debug("Successfully retrieved data from {}", urlBuilder);
+            return gson.fromJson(response.body(), JsonObject.class);
+        } else {
+            logger.error("Using a session object from other PK4J implementations is unsupported!");
+            throw new IllegalArgumentException("session must be an instance of RestUserSession");
         }
-
-        logger.debug("Trying to retrieve data from {} for user {} ...", url.value(), user.getUsername());
-
-        StringBuilder urlBuilder = new StringBuilder(url.value());
-
-        if (resourceID != -1) {
-            urlBuilder.append("/").append(resourceID);
-        }
-
-        urlBuilder.append("?user_id=").append(user.getUserID().get());
-        urlBuilder.append("&study_id=").append(user.getStudyID().get());
-
-        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(urlBuilder.toString())).header("Content-Type", "application/json").header("Authorization", String.join("", "Bearer ", user.getSessionToken().get())).GET().build();
-
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-        if (response.statusCode() == 401) {
-            logger.debug("User {}'s session token was inactive, trying to log back in...", user.getUsername());
-            login(user);
-            return getRequest(user, url);
-        }
-
-        if (response.statusCode() != 200) throw new EHMSException(response.statusCode());
-
-        logger.debug("Successfully retrieved data from {}, for user {}", url.value(), user.getUsername());
-        return gson.fromJson(response.body(), JsonObject.class);
     }
 
-
-    private void login(EHMSUser user) throws IOException, InterruptedException {
-        final String loginBody = "{\"username\":\"%s\",\"password\":\"%s\"}";
-
+    public EHMSUserSession login(EHMSUser user) throws IOException, InterruptedException {
+        String loginBody = "{\"username\":\"%s\",\"password\":\"%s\"}";
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create(RestEHMSUrl.AUTHENTICATE.value())).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(String.format(loginBody, user.getUsername(), user.getPassword()))).build();
 
+        logger.debug("Trying to log in as user \"{}\"", user.getUsername());
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        if (response.statusCode() == 403)
-            throw new IllegalArgumentException(String.format("Authentication failed for user %s, are the login details correct?", user.getUsername()));
+        if (response.statusCode() == 403) {
+            logger.warn("Authentication for user \"{}\" failed, are the login details correct?", user.getUsername());
+            throw new InvalidCredentialsException(user.getUsername());
+        }
 
         if (response.statusCode() != 200) throw new EHMSException(response.statusCode());
 
-        logger.debug("Successfully logged in as user {}", user.getUsername());
+        logger.debug("Successfully logged in as user \"{}\"", user.getUsername());
 
         JsonObject responseBody = gson.fromJson(response.body(), JsonObject.class);
         JsonObject userData = responseBody.getAsJsonObject("user");
+        String token = userData.get("token").getAsString();
+        String userID = userData.get("id").getAsString();
         String studyID = responseBody.getAsJsonObject("ouStudyCourses").getAsJsonObject("ouStudyCoursesRow").get("id").getAsString();
 
-        user.setSessionToken(userData.get("token").getAsString());
-        user.setUserID(userData.get("id").getAsString());
-        user.setStudyID(studyID);
+        return new RestUserSession(token, userID, studyID);
     }
 }

--- a/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestPK4J.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestPK4J.java
@@ -2,7 +2,9 @@ package pl.eukon05.pk4j.core.impl.rest;
 
 import com.google.gson.JsonObject;
 import pl.eukon05.pk4j.core.EHMSUser;
+import pl.eukon05.pk4j.core.EHMSUserSession;
 import pl.eukon05.pk4j.core.PK4J;
+import pl.eukon05.pk4j.exception.EHMSExpiredTokenException;
 import pl.eukon05.pk4j.model.Announcement;
 import pl.eukon05.pk4j.model.UserDetails;
 
@@ -10,39 +12,52 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RestPK4J implements PK4J {
+public final class RestPK4J extends PK4J {
     private static final RestPK4J INSTANCE = new RestPK4J(new RestEHMSWebClient(), new JsonToModelMapper());
     private final JsonToModelMapper mapper;
-    private final RestEHMSWebClient client;
 
     private RestPK4J(RestEHMSWebClient ehmsWebClient, JsonToModelMapper mapper) {
-        this.client = ehmsWebClient;
+        super(ehmsWebClient);
         this.mapper = mapper;
     }
 
     @Override
     public List<Announcement> getAnnouncements(EHMSUser user) throws IOException, InterruptedException {
-        JsonObject shortAnnouncements = client.getRequest(user, RestEHMSUrl.ALL_ANNOUNCEMENTS);
+        EHMSUserSession session = getSession(user);
 
-        List<Long> annIds = shortAnnouncements.getAsJsonArray("data")
-                .asList()
-                .stream()
-                .map(el -> el.getAsJsonObject().get("id").getAsLong())
-                .toList();
+        try {
+            JsonObject shortAnnouncements = client.getRequest(session, RestEHMSUrl.ALL_ANNOUNCEMENTS);
 
-        List<Announcement> result = new ArrayList<>();
-        for (long id : annIds) {
-            JsonObject announcement = client.getRequest(user, RestEHMSUrl.ANNOUNCEMENT, id);
-            result.add(mapper.announcementFromJson(announcement.getAsJsonObject("data"), id));
+            List<Long> annIds = shortAnnouncements.getAsJsonArray("data")
+                    .asList()
+                    .stream()
+                    .map(el -> el.getAsJsonObject().get("id").getAsLong())
+                    .toList();
+
+            List<Announcement> result = new ArrayList<>();
+            for (long id : annIds) {
+                JsonObject announcement = client.getRequest(session, RestEHMSUrl.ANNOUNCEMENT, id);
+                result.add(mapper.announcementFromJson(announcement.getAsJsonObject("data"), id));
+            }
+
+            return result;
+        } catch (EHMSExpiredTokenException e) {
+            sessionCache.remove(user.getUsername());
+            return getAnnouncements(user);
         }
-
-        return result;
     }
 
     @Override
     public UserDetails getUserDetails(EHMSUser user) throws IOException, InterruptedException {
-        JsonObject details = client.getRequest(user, RestEHMSUrl.USER_DETAILS);
-        return mapper.detailsFromJson(details.getAsJsonArray("data").get(0).getAsJsonObject());
+        EHMSUserSession session = getSession(user);
+
+        try {
+            JsonObject details = client.getRequest(session, RestEHMSUrl.USER_DETAILS);
+            return mapper.detailsFromJson(details.getAsJsonArray("data").get(0).getAsJsonObject());
+        } catch (EHMSExpiredTokenException e) {
+            sessionCache.remove(user.getUsername());
+            return getUserDetails(user);
+        }
     }
 
     public static RestPK4J getInstance() {

--- a/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestUserSession.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/rest/RestUserSession.java
@@ -1,0 +1,22 @@
+package pl.eukon05.pk4j.core.impl.rest;
+
+import pl.eukon05.pk4j.core.EHMSUserSession;
+
+final class RestUserSession extends EHMSUserSession {
+    private final String userID;
+    private final String studyID;
+
+    public RestUserSession(String sessionToken, String userID, String studyID) {
+        super(sessionToken);
+        this.userID = userID;
+        this.studyID = studyID;
+    }
+
+    public String getUserID() {
+        return userID;
+    }
+
+    public String getStudyID() {
+        return studyID;
+    }
+}

--- a/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ElementToModelMapper.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ElementToModelMapper.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-class ElementToModelMapper {
+final class ElementToModelMapper {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
 
     Announcement announcementFromElement(Element element) {

--- a/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperEHMSUrl.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperEHMSUrl.java
@@ -1,6 +1,8 @@
 package pl.eukon05.pk4j.core.impl.scraper;
 
-enum ScraperEHMSUrl {
+import pl.eukon05.pk4j.core.EHMSUrlEnum;
+
+enum ScraperEHMSUrl implements EHMSUrlEnum {
     BASE("https://ehms.pk.edu.pl/standard/"),
     USER_DETAILS("https://ehms.pk.edu.pl/standard/?tab=2");
 

--- a/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperPK4J.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperPK4J.java
@@ -1,9 +1,13 @@
 package pl.eukon05.pk4j.core.impl.scraper;
 
+import com.google.gson.JsonObject;
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import pl.eukon05.pk4j.core.EHMSUser;
+import pl.eukon05.pk4j.core.EHMSUserSession;
 import pl.eukon05.pk4j.core.PK4J;
+import pl.eukon05.pk4j.exception.EHMSExpiredTokenException;
 import pl.eukon05.pk4j.model.Announcement;
 import pl.eukon05.pk4j.model.UserDetails;
 
@@ -12,13 +16,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-public final class ScraperPK4J implements PK4J {
+public final class ScraperPK4J extends PK4J {
     private static final ScraperPK4J INSTANCE = new ScraperPK4J(new ScraperEHMSWebClient(), new ElementToModelMapper());
     private final ElementToModelMapper mapper;
-    private final ScraperEHMSWebClient client;
 
     private ScraperPK4J(ScraperEHMSWebClient ehmsWebClient, ElementToModelMapper mapper) {
-        this.client = ehmsWebClient;
+        super(ehmsWebClient);
         this.mapper = mapper;
     }
 
@@ -27,16 +30,33 @@ public final class ScraperPK4J implements PK4J {
     }
 
     @Override
-    public List<Announcement> getAnnouncements(EHMSUser user) throws IOException {
-        Document doc = client.getRequest(user, ScraperEHMSUrl.BASE);
-        Elements announcements = doc.selectXpath("//*[@id=\"content\"]/div/div[2]/div/div[2]/table/tbody").select("tr");
+    public List<Announcement> getAnnouncements(EHMSUser user) throws IOException, EHMSExpiredTokenException, InterruptedException {
+        EHMSUserSession session = getSession(user);
 
-        return announcements.stream().map(mapper::announcementFromElement).sorted(Comparator.comparing(Announcement::lastModified).reversed()).toList();
+        try {
+            JsonObject jsDoc = client.getRequest(session, ScraperEHMSUrl.BASE);
+            Document doc = Jsoup.parse(jsDoc.get("Document").getAsString());
+            Elements announcements = doc.selectXpath("//*[@id=\"content\"]/div/div[2]/div/div[2]/table/tbody").select("tr");
+
+            return announcements.stream().map(mapper::announcementFromElement).sorted(Comparator.comparing(Announcement::lastModified).reversed()).toList();
+        } catch (EHMSExpiredTokenException e) {
+            sessionCache.remove(user.getUsername());
+            return getAnnouncements(user);
+        }
     }
 
     @Override
-    public UserDetails getUserDetails(EHMSUser user) throws IOException {
-        Document doc = client.getRequest(user, ScraperEHMSUrl.USER_DETAILS);
-        return mapper.userDetailsFromElement(Objects.requireNonNull(doc.select("#content > div > div.p-3").first()));
+    public UserDetails getUserDetails(EHMSUser user) throws IOException, EHMSExpiredTokenException, InterruptedException {
+        EHMSUserSession session = getSession(user);
+
+        try {
+            JsonObject jsDoc = client.getRequest(session, ScraperEHMSUrl.USER_DETAILS);
+            Document doc = Jsoup.parse(jsDoc.get("Document").getAsString());
+
+            return mapper.userDetailsFromElement(Objects.requireNonNull(doc.select("#content > div > div.p-3").first()));
+        } catch (EHMSExpiredTokenException e) {
+            sessionCache.remove(user.getUsername());
+            return getUserDetails(user);
+        }
     }
 }

--- a/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperUserSession.java
+++ b/src/main/java/pl/eukon05/pk4j/core/impl/scraper/ScraperUserSession.java
@@ -1,0 +1,9 @@
+package pl.eukon05.pk4j.core.impl.scraper;
+
+import pl.eukon05.pk4j.core.EHMSUserSession;
+
+final class ScraperUserSession extends EHMSUserSession {
+    public ScraperUserSession(String sessionToken) {
+        super(sessionToken);
+    }
+}

--- a/src/main/java/pl/eukon05/pk4j/exception/EHMSException.java
+++ b/src/main/java/pl/eukon05/pk4j/exception/EHMSException.java
@@ -1,6 +1,6 @@
 package pl.eukon05.pk4j.exception;
 
-public class EHMSException extends RuntimeException {
+public final class EHMSException extends RuntimeException {
 
     public EHMSException(int statusCode) {
         super(String.format("EHMS returned an unexpected status code: %d", statusCode));

--- a/src/main/java/pl/eukon05/pk4j/exception/EHMSExpiredTokenException.java
+++ b/src/main/java/pl/eukon05/pk4j/exception/EHMSExpiredTokenException.java
@@ -1,0 +1,4 @@
+package pl.eukon05.pk4j.exception;
+
+public final class EHMSExpiredTokenException extends RuntimeException {
+}

--- a/src/main/java/pl/eukon05/pk4j/exception/InvalidCredentialsException.java
+++ b/src/main/java/pl/eukon05/pk4j/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package pl.eukon05.pk4j.exception;
+
+public final class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String username) {
+        super(String.format("Authentication failed for user %s, are the login details correct?", username));
+    }
+}

--- a/src/main/java/pl/eukon05/pk4j/exception/RateLimitExceededException.java
+++ b/src/main/java/pl/eukon05/pk4j/exception/RateLimitExceededException.java
@@ -1,6 +1,6 @@
 package pl.eukon05.pk4j.exception;
 
-public class RateLimitExceededException extends RuntimeException {
+public final class RateLimitExceededException extends RuntimeException {
 
     public RateLimitExceededException(String userID) {
         super(String.format("User %s got rate-limited! Please wait or solve the captcha on another device before trying to log in again!", userID));

--- a/src/main/java/pl/eukon05/pk4j/model/Gender.java
+++ b/src/main/java/pl/eukon05/pk4j/model/Gender.java
@@ -4,6 +4,6 @@ public enum Gender {
     FEMALE, MALE;
 
     public static Gender fromString(String value) {
-        return value.equals("Kobieta") ? FEMALE : MALE;
+        return value.equalsIgnoreCase("kobieta") ? FEMALE : MALE;
     }
 }


### PR DESCRIPTION
- Abstracted the details of EHMSUser to specific EHMSUserSession classes
- Made PK4J into an abstract class, so that classes inheriting it will contain a session map and an EHMSWebClient by default
- Created an EHMSWebClient interface to make a binding contract with classes that implement it, instead of having two completely different web clients
- PK4J implementations are now responsible for retrying an operation after an expired session is detected, instead of the web clients
- EHMS url enums are now implementing the EHMSUrlEnum interface, so that the web client interface can function regardless of implementation - validity of the URL is checked by the implementing web client, for ex. trying to use a URL for a scraper impl. in a rest impl. will result in an exception being thrown
- PK4J implementations are now responsible for managing a cache of user sessions, thus making the EHMSUser object universal, regardless of currently used implementation (using the same user object in both impl.s at the same time won't result in constant re-logins, as the session data for each impl. is cached by it)
- Made as many classes as possible "final"